### PR TITLE
A bunch of options, including --rtsopts and --high-core-rtsopts

### DIFF
--- a/bench/bench.sh
+++ b/bench/bench.sh
@@ -10,13 +10,12 @@ default_profile_spec=$(jq '.[0]' "$specs_json")
 
 function main() {
         local verbose debug trace= profspec prof nix_shell_cmd
-        local name= cores= max_jobs= iterations=
+        local name= cores= iterations=
 
         while test $# -ge 1
         do case "$1" in
            --cores | -c )      if test "$2" = 'all'
                                then cores=0; else cores=$2; fi; shift;;
-           --max-jobs | -j )   max_jobs=$2; shift;;
            --iterations | -n ) iterations=$2; shift;;
 
            --cls )             echo -en "\ec";;
@@ -32,7 +31,6 @@ function main() {
                    (\$ARGS.positional | add)
                    " --jsonargs \
                      ${cores:+     "{ \"cores\":      $cores }"} \
-                     ${max_jobs:+  "{ \"max_jobs\":   $max_jobs }"} \
                      ${iterations:+"{ \"iterations\": $iterations }"})
 
         oprint "profile spec: $(jq -C . <<<$profspec)"
@@ -96,7 +94,6 @@ function prebuild_profile() {
                 --no-build-output
                 --no-out-link
                 --cores    4
-                --max-jobs 1
                 "${drvs[@]}"
         )
         dprint nix-build "${args[@]}"
@@ -141,7 +138,6 @@ function build_derivation() {
         args=(
                 --no-build-output
                 --cores    "$(jqevq "$build" .cores)"
-                --max-jobs "$(jqevq "$build" .max_jobs)"
                            "$(jqevq "$build" .derivation)"
         )
         dprint    --realise --check "${args[@]}"

--- a/bench/lib.sh
+++ b/bench/lib.sh
@@ -44,6 +44,10 @@ jqevqlist() {
         jqevq "$val" "$q | join (\" \")" "$@"
 }
 
+jqtest() {
+        jq --exit-status "$@" > /dev/null
+}
+
 json_file_append() {
         local f=$1 extra=$2 tmp; shift 2
         tmp=$(mktemp --tmpdir)
@@ -74,10 +78,22 @@ args_to_json() {
         words_to_lines <<<"$@" | jq --raw-input | jq --slurp --compact-output
 }
 
+merge_json_attrs() {
+        jqev "(\$ARGS.positional | add)" --jsonargs "$@" --compact-output
+}
+
 map() {
         f=$1; shift
 
         for x in "$@"
         do $f $x || return 1
+        done
+}
+
+map2() {
+        f=$1; a=$2; shift 2
+
+        for x in "$@"
+        do "$f" "$a" "$x" || return 1
         done
 }

--- a/bench/lib.sh
+++ b/bench/lib.sh
@@ -70,6 +70,14 @@ words_to_lines() {
         sed 's_ _\n_g'
 }
 
-shell_list_to_json() {
-        words_to_lines | jq --raw-input | jq --slurp --compact-output
+args_to_json() {
+        words_to_lines <<<"$@" | jq --raw-input | jq --slurp --compact-output
+}
+
+map() {
+        f=$1; shift
+
+        for x in "$@"
+        do $f $x || return 1
+        done
 }

--- a/nix/overrides.nix
+++ b/nix/overrides.nix
@@ -9,11 +9,6 @@ let
           (doJailbreak (old.callCabal2nixWithOptions repo (pkgs.fetchFromGitHub {
             inherit owner repo rev sha256;
            }) cabalExtras {}));
-  # overcabal = pkgs.haskell.lib.overrideCabal;
-  # hubsrc    =      repo: rev: sha256:       pkgs.fetchgit { url = "https://github.com/" + repo; rev = rev; sha256 = sha256; };
-  # overc     = old:                    args: overcabal old (oldAttrs: (oldAttrs // args));
-  # overhub   = old: repo: rev: sha256: args: overc old ({ src = hubsrc repo rev sha256; }       // args);
-  # overhage  = old: version:   sha256: args: overc old ({ version = version; sha256 = sha256; } // args);
 in {
   # async-timer           = dontCheck (overrideCabal old.async-timer  (old: { broken = false; }));
   cabal-install = overrideCabal old.cabal-install (drv: {

--- a/profile-specs.json
+++ b/profile-specs.json
@@ -1,4 +1,30 @@
 [ { "name":           "clash"
+  , "cores":          4
+  , "iterations":     3
+  , "attributes":
+    [ "clash-prelude"
+    , "clash-lib"
+    , "clash-ghc"
+    ]
+  }
+, { "name":           "clash"
+  , "cores":          16
+  , "iterations":     3
+  , "rtsopts":        "-qn8 -A32M"
+  , "attributes":
+    [ "clash-prelude"
+    , "clash-lib"
+    , "clash-ghc"
+    ]
+  }
+, { "name":           "ghc"
+  , "cores":          4
+  , "iterations":     1
+  , "attributes":
+    [ "ghc"
+    ]
+  }
+, { "name":           "clash"
   , "cores":          1
   , "iterations":     3
   , "attributes":
@@ -26,7 +52,7 @@
     ]
   }
 , { "name":           "clash"
-  , "cores":          4
+  , "cores":          5
   , "iterations":     3
   , "attributes":
     [ "clash-prelude"
@@ -35,7 +61,25 @@
     ]
   }
 , { "name":           "clash"
-  , "cores":          1
+  , "cores":          6
+  , "iterations":     3
+  , "attributes":
+    [ "clash-prelude"
+    , "clash-lib"
+    , "clash-ghc"
+    ]
+  }
+, { "name":           "clash"
+  , "cores":          7
+  , "iterations":     3
+  , "attributes":
+    [ "clash-prelude"
+    , "clash-lib"
+    , "clash-ghc"
+    ]
+  }
+, { "name":           "clash"
+  , "cores":          8
   , "iterations":     3
   , "attributes":
     [ "clash-prelude"

--- a/profile-specs.json
+++ b/profile-specs.json
@@ -1,6 +1,5 @@
 [ { "name":           "clash"
   , "cores":          1
-  , "max_jobs":       1
   , "iterations":     3
   , "attributes":
     [ "clash-prelude"
@@ -10,7 +9,6 @@
   }
 , { "name":           "clash"
   , "cores":          2
-  , "max_jobs":       1
   , "iterations":     3
   , "attributes":
     [ "clash-prelude"
@@ -20,7 +18,6 @@
   }
 , { "name":           "clash"
   , "cores":          3
-  , "max_jobs":       1
   , "iterations":     3
   , "attributes":
     [ "clash-prelude"
@@ -30,7 +27,6 @@
   }
 , { "name":           "clash"
   , "cores":          4
-  , "max_jobs":       1
   , "iterations":     3
   , "attributes":
     [ "clash-prelude"
@@ -40,7 +36,6 @@
   }
 , { "name":           "clash"
   , "cores":          1
-  , "max_jobs":       2
   , "iterations":     3
   , "attributes":
     [ "clash-prelude"


### PR DESCRIPTION
This implements:

1. `--high-core-rtsopts` that passes `+RTS -A32M -q8n -RTS` to ghc
1. `--rtsopts OPTS` for custom options
1. `--attr NAME` (and the `ghc` attribute to time GHC builds), can be specified multiple times
1. `--profile NR` to pick profile from the JSON profile list, can be specified multiple times
1. Last, but not least: `--help`